### PR TITLE
Add repository root to Quartus SEARCH_PATH for DSP ROM init files

### DIFF
--- a/projects/snes_pocket.qsf
+++ b/projects/snes_pocket.qsf
@@ -78,3 +78,4 @@ set_global_assignment -name FITTER_AGGRESSIVE_ROUTABILITY_OPTIMIZATION ALWAYS
 set_global_assignment -name ALM_REGISTER_PACKING_EFFORT LOW
 set_global_assignment -name NUM_PARALLEL_PROCESSORS 4
 set_instance_assignment -name PARTITION_HIERARCHY root_partition -to | -section_id Top
+set_global_assignment -name SEARCH_PATH ../


### PR DESCRIPTION
The DSP program and data ROMs load their contents from `.mif` files referenced relative to the repository root (`rtl/upstream/chip/DSP/dsp11b23410_{p,d}.mif` in `DSPn.vhd`), but Quartus resolves relative paths from the project directory (`projects/`), so the files are not found during compilation.

Add `../` to `SEARCH_PATH` so Quartus also looks from the repository root and resolves the DSP ROM init files correctly.